### PR TITLE
cloud nat manual option

### DIFF
--- a/cloud-nat/CHANGELOG.md
+++ b/cloud-nat/CHANGELOG.md
@@ -4,7 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [next version]
+## 1.1.0
+### Added
+* Ability to configure nat router with `var.nat_ip_allocate_option`
+* Added `var.cloud_nat_address_count` to specify the number of public NAT IP addresses
+
+
+## 1.0.0
 
 ### deprecations
 

--- a/cloud-nat/README.md
+++ b/cloud-nat/README.md
@@ -5,7 +5,7 @@ The set up is the same as for the default module. You'd fill out the network.tf 
 
 ```terraform
 module "network" {
-  source = "git@github.com:FairwindsOps/terraform-gcp-vpc-native.git//cloud-nat?ref=v0.0.1"
+  source = "git@github.com:FairwindsOps/terraform-gcp-vpc-native.git//cloud-nat?ref=v1.1.0"
   // base network parameters
   network_name               = "project-kube-staging-1"
   subnetwork_name            = "project-staging-1"

--- a/cloud-nat/README.md
+++ b/cloud-nat/README.md
@@ -5,7 +5,7 @@ The set up is the same as for the default module. You'd fill out the network.tf 
 
 ```terraform
 module "network" {
-  source = "git@github.com:FairwindsOps/terraform-gcp-vpc-native.git//cloud-nat?ref=v1.1.0"
+  source = "git@github.com:FairwindsOps/terraform-gcp-vpc-native.git//cloud-nat?ref=cloud-nat-v1.1.0"
   // base network parameters
   network_name               = "project-kube-staging-1"
   subnetwork_name            = "project-staging-1"

--- a/cloud-nat/README.md
+++ b/cloud-nat/README.md
@@ -3,8 +3,7 @@ The `cloud-nat` module is similar to the `default` module, but it additionally c
 
 The set up is the same as for the default module. You'd fill out the network.tf like so, specifying the path of the cloud-nat module instead:
 
-```
-```
+```terraform
 module "network" {
   source = "git@github.com:FairwindsOps/terraform-gcp-vpc-native.git//cloud-nat?ref=v0.0.1"
   // base network parameters
@@ -18,5 +17,9 @@ module "network" {
   subnetwork_pods      = "10.128.64.0/18"
   subnetwork_services  = "10.128.32.0/20"
 
+  // Optional Variables 
+  // AUTO_ONLY or MANUAL_ONLY NAT allocation
+  nat_ip_allocate_option = "MANUAL_ONLY"
+  cloud_nat_address_count = 2
 }
 ```


### PR DESCRIPTION
Added the ability to provision NAT gateways with a specified list of public ip addresses. This adds two new input variables that contain default values, so backwards compatibility is maintained. 

Desired new version is `cloud-nat-v1.1.0`