### PR TITLE
Additional cloud nat params

### DIFF
--- a/default/CHANGELOG.md
+++ b/default/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 * added variable for `min_ports_per_vm`
+* added variable `cloud_nat_log_config_filter`
 
 ### Removed
 * removed unused variable `enable_flow_logs`

--- a/default/CHANGELOG.md
+++ b/default/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 2.2.0
+
+### Added
+* added variable for `min_ports_per_vm`
+
+### Removed
+* removed unused variable `enable_flow_logs`
+
+## 2.1.0
+
+### Removed
+* `enable_flow_logs` has been deprecated and removed
+
 ## 2.0.0
 ### Breaking
 

--- a/default/README.md
+++ b/default/README.md
@@ -13,9 +13,9 @@ module "network" {
   enable_flow_logs           = "false"
 
   //specify the staging subnetwork primary and secondary CIDRs for IP aliasing
-  subnetwork_range    = "10.128.64.0/21"
-  subnetwork_pods     = "10.128.0.0/14"
-  subnetwork_services = "10.128.0.0/18"
+  subnetwork_range    = "10.64.0.0/20"
+  subnetwork_pods     = "10.128.0.0/12"
+  subnetwork_services = "10.64.32.0/19"
 
   //optional cloud-nat inputs
   enable_cloud_nat = true

--- a/default/README.md
+++ b/default/README.md
@@ -1,7 +1,7 @@
 ### Default module example parameters
-The `default` module will create a VPC-native network for Kubernetes clusters. This module can be configured to provision a Cloud NAT gateway. The Cloud NAT gateway can also be configured with `AUTO_ONLY` or `MANUAL_ONLY` options. If `MANUAL_ONLY` is chosen, `cloud_nat_address_count` can be used to select the desired number of public IP addresses. 
+The `default` module will create a VPC-native network for Kubernetes clusters. This module can be configured to provision a Cloud NAT gateway. The Cloud NAT gateway can also be configured with `AUTO_ONLY` or `MANUAL_ONLY` options. If `MANUAL_ONLY` is chosen, `cloud_nat_address_count` can be used to select the desired number of public IP addresses.
 
-Fill out your `network.tf` like so: 
+Fill out your `network.tf` like so:
 
 ```
 module "network" {
@@ -13,9 +13,9 @@ module "network" {
   enable_flow_logs           = "false"
 
   //specify the staging subnetwork primary and secondary CIDRs for IP aliasing
-  subnetwork_range     = "10.128.0.0/20"
-  subnetwork_pods      = "10.128.64.0/18"
-  subnetwork_services  = "10.128.32.0/20"
+  subnetwork_range    = "10.68.64.0/21"
+  subnetwork_pods     = "10.64.0.0/14"
+  subnetwork_services = "10.68.0.0/18"
 
   //optional cloud-nat inputs
   enable_cloud_nat = true

--- a/default/README.md
+++ b/default/README.md
@@ -13,9 +13,9 @@ module "network" {
   enable_flow_logs           = "false"
 
   //specify the staging subnetwork primary and secondary CIDRs for IP aliasing
-  subnetwork_range    = "10.68.64.0/21"
-  subnetwork_pods     = "10.64.0.0/14"
-  subnetwork_services = "10.68.0.0/18"
+  subnetwork_range    = "10.128.64.0/21"
+  subnetwork_pods     = "10.128.0.0/14"
+  subnetwork_services = "10.128.0.0/18"
 
   //optional cloud-nat inputs
   enable_cloud_nat = true

--- a/default/main.tf
+++ b/default/main.tf
@@ -120,7 +120,7 @@ resource "google_compute_router_nat" "nat_router" {
   region                             = var.region
   nat_ip_allocate_option             = var.nat_ip_allocate_option
   nat_ips                            = local.nat_ips
-  min_ports_per_vm                   = var.min_ports_per_vm
+  min_ports_per_vm                   = var.cloud_nat_min_ports_per_vm
   source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"
 }
 

--- a/default/main.tf
+++ b/default/main.tf
@@ -50,6 +50,12 @@ variable "cloud_nat_address_count" {
   default     = 1
 }
 
+variable "cloud_nat_min_ports_per_vm" {
+  description = "Minimum number of ports allocated to a VM from this NAT."
+  type        = number
+  default     = 64
+}
+
 locals {
   ## the following locals modify resource creation behavior depending on var.nat_ip_allocate_option
   enable_cloud_nat        = var.enable_cloud_nat == true ? 1 : 0
@@ -114,6 +120,7 @@ resource "google_compute_router_nat" "nat_router" {
   region                             = var.region
   nat_ip_allocate_option             = var.nat_ip_allocate_option
   nat_ips                            = local.nat_ips
+  min_ports_per_vm                   = var.min_ports_per_vm
   source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"
 }
 

--- a/default/main.tf
+++ b/default/main.tf
@@ -26,10 +26,6 @@ variable "region" {
   description = "region to use"
 }
 
-variable "enable_flow_logs" {
-  description = "whether to turn on flow logs or not"
-}
-
 variable "enable_cloud_nat" {
   # https://cloud.google.com/nat/docs/overview#ip_address_allocation
   description = "Setup Cloud NAT gateway for VPC"

--- a/default/main.tf
+++ b/default/main.tf
@@ -124,9 +124,12 @@ resource "google_compute_router_nat" "nat_router" {
   min_ports_per_vm                   = var.cloud_nat_min_ports_per_vm
   source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"
 
-  log_config {
-    enable = var.cloud_nat_log_config_filter != null ? true : false
-    filter = var.cloud_nat_log_config_filter
+  dynamic "log_config" {
+    for_each = var.cloud_nat_log_config_filter == null ? [] : list(true)
+    content {
+      enable = var.cloud_nat_log_config_filter != null ? true : false
+      filter = var.cloud_nat_log_config_filter
+    }
   }
 }
 

--- a/default/main.tf
+++ b/default/main.tf
@@ -52,6 +52,11 @@ variable "cloud_nat_min_ports_per_vm" {
   default     = 64
 }
 
+variable "cloud_nat_log_config_filter" {
+  description = "Specifies the desired filtering of logs on this NAT"
+  default     = null
+}
+
 locals {
   ## the following locals modify resource creation behavior depending on var.nat_ip_allocate_option
   enable_cloud_nat        = var.enable_cloud_nat == true ? 1 : 0
@@ -118,6 +123,11 @@ resource "google_compute_router_nat" "nat_router" {
   nat_ips                            = local.nat_ips
   min_ports_per_vm                   = var.cloud_nat_min_ports_per_vm
   source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"
+
+  log_config {
+    enable = var.cloud_nat_log_config_filter != null ? true : false
+    filter = var.cloud_nat_log_config_filter
+  }
 }
 
 /** provide outputs to be used in GKE cluster creation **/

--- a/default/main.tf
+++ b/default/main.tf
@@ -127,7 +127,7 @@ resource "google_compute_router_nat" "nat_router" {
   dynamic "log_config" {
     for_each = var.cloud_nat_log_config_filter == null ? [] : list(true)
     content {
-      enable = var.cloud_nat_log_config_filter != null ? true : false
+      enable = var.cloud_nat_log_config_filter == null ? false : true
       filter = var.cloud_nat_log_config_filter
     }
   }


### PR DESCRIPTION
Added new variables and fields for cloud nat `min_ports_per_vm` and `log_filter`. Updated the CHANGELOG to reflect 2.1.0 changes. Updated README with more suitable subnet sizes.

Non breaking, backwards compatible change.

Desired tag: `default-v2.2.0`