### PR TITLE
bug fix for cloud nat logging

### DIFF
--- a/default/CHANGELOG.md
+++ b/default/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 2.2.1
+
+### Fixed
+* updated the log_config logic to prevent changes on each run
+
 ## 2.2.0
 
 ### Added

--- a/default/main.tf
+++ b/default/main.tf
@@ -124,12 +124,9 @@ resource "google_compute_router_nat" "nat_router" {
   min_ports_per_vm                   = var.cloud_nat_min_ports_per_vm
   source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"
 
-  dynamic "log_config" {
-    for_each = var.cloud_nat_log_config_filter == null ? [] : list(true)
-    content {
-      enable = var.cloud_nat_log_config_filter == null ? false : true
-      filter = var.cloud_nat_log_config_filter
-    }
+  log_config {
+    enable = var.cloud_nat_log_config_filter == null ? false : true
+    filter = var.cloud_nat_log_config_filter == null ? "ALL" : var.cloud_nat_log_config_filter
   }
 }
 


### PR DESCRIPTION
updated `log_config` logic. Using a dynamic and it setting values to `null` prompted changes on each run when `log_config` is turned off. 

desired tag `default-v2.2.1`