### PR TITLE
Mg/update nat router

### DIFF
--- a/default/CHANGELOG.md
+++ b/default/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 2.2.2
+
+### Added
+* added variable for `cloud_nat_tcp_transitory_idle_timeout_sec`
 ## 2.2.1
 
 ### Fixed

--- a/default/main.tf
+++ b/default/main.tf
@@ -52,6 +52,13 @@ variable "cloud_nat_min_ports_per_vm" {
   default     = 64
 }
 
+variable "cloud_nat_tcp_transitory_idle_timeout_sec" {
+  # https://cloud.google.com/nat/docs/overview#specs-timeouts
+  description = "Timeout in seconds for TCP transitory connections."
+  type        = number
+  default     = 30
+}
+
 variable "cloud_nat_log_config_filter" {
   description = "Specifies the desired filtering of logs on this NAT"
   default     = null
@@ -123,6 +130,7 @@ resource "google_compute_router_nat" "nat_router" {
   nat_ips                            = local.nat_ips
   min_ports_per_vm                   = var.cloud_nat_min_ports_per_vm
   source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"
+  tcp_transitory_idle_timeout_sec    = var.cloud_nat_tcp_transitory_idle_timeout_sec
 
   log_config {
     enable = var.cloud_nat_log_config_filter == null ? false : true


### PR DESCRIPTION
Added new variable for cloud nat tcp_transitory_idle_timeout_sec. Updated the CHANGELOG to reflect 2.2.2 changes. 

Non breaking, backwards compatible change.

Desired tag: default-v2.2.2